### PR TITLE
feat: add mobile controls and next piece preview

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,0 +1,11 @@
+:root {
+    --background-color: #000;
+    --text-color: #fff;
+    --theme-color: #00f;
+}
+
+body.light {
+    --background-color: #fff;
+    --text-color: #000;
+    --theme-color: #0066ff;
+}

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -1,0 +1,5 @@
+function changeColorScheme() {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+        document.body.classList.add('light');
+    }
+}

--- a/tetris.css
+++ b/tetris.css
@@ -1,6 +1,6 @@
 body {
     font-family: 'Montserrat', sans-serif;
-    background: var(--background-color, #000);
+    background: linear-gradient(135deg, var(--background-color, #000), #111);
     color: var(--text-color, #fff);
     display: flex;
     flex-direction: column;
@@ -21,13 +21,86 @@ body {
     margin-top: 10px;
 }
 
+#game-wrapper {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+    margin-top: 10px;
+}
+
+#sidebar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#next-title {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+#next {
+    border: 2px solid var(--theme-color, #00f);
+    background: #000;
+    margin-top: 10px;
+}
+
 #score {
     margin-top: 10px;
     font-size: 1.2rem;
     font-weight: bold;
 }
 
+#controls {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+}
+
+.control-row {
+    display: flex;
+    gap: 10px;
+}
+
+#controls button {
+    width: 60px;
+    height: 60px;
+    border: none;
+    border-radius: 50%;
+    background: var(--theme-color, #00f);
+    color: var(--background-color, #000);
+    font-size: 1.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+}
+
+#controls button.wide {
+    width: 150px;
+    border-radius: 30px;
+}
+
+#controls button:active {
+    transform: scale(0.95);
+}
+
 footer {
     margin-top: auto;
     padding: 10px;
+}
+
+@media (max-width: 600px) {
+    #game-wrapper {
+        flex-direction: column;
+        align-items: center;
+    }
+    #sidebar {
+        flex-direction: row;
+        gap: 20px;
+        margin-top: 10px;
+    }
+    #next-title {
+        align-self: center;
+    }
 }

--- a/tetris.html
+++ b/tetris.html
@@ -18,8 +18,27 @@
 <body>
     <div id="game-container">
         <h1 id="game-title">Tetris</h1>
-        <canvas id="tetris" width="200" height="400" aria-label="Tetris play field"></canvas>
-        <div id="score" aria-live="polite" role="status">Score: 0</div>
+        <div id="game-wrapper">
+            <canvas id="tetris" width="200" height="400" aria-label="Tetris play field"></canvas>
+            <div id="sidebar">
+                <h2 id="next-title">Next</h2>
+                <canvas id="next" width="80" height="80" aria-label="Next piece preview"></canvas>
+                <div id="score" aria-live="polite" role="status">Score: 0</div>
+            </div>
+        </div>
+        <div id="controls">
+            <div class="control-row">
+                <button id="btn-rotate" aria-label="Rotate piece">⟳</button>
+            </div>
+            <div class="control-row">
+                <button id="btn-left" aria-label="Move left">◀</button>
+                <button id="btn-down" aria-label="Soft drop">▼</button>
+                <button id="btn-right" aria-label="Move right">▶</button>
+            </div>
+            <div class="control-row">
+                <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
+            </div>
+        </div>
     </div>
     <script src="tetris.js"></script>
     <script src="color-scheme.js"></script>

--- a/tetris.js
+++ b/tetris.js
@@ -2,6 +2,10 @@ const canvas = document.getElementById('tetris');
 const context = canvas.getContext('2d');
 context.scale(20, 20);
 
+const nextCanvas = document.getElementById('next');
+const nextContext = nextCanvas.getContext('2d');
+nextContext.scale(20, 20);
+
 function createMatrix(w, h) {
     const matrix = [];
     while (h--) {
@@ -100,15 +104,26 @@ function arenaSweep() {
     }
 }
 
-function drawMatrix(matrix, offset) {
+function drawMatrix(matrix, offset, ctx = context) {
     matrix.forEach((row, y) => {
         row.forEach((value, x) => {
             if (value !== 0) {
-                context.fillStyle = colors[value];
-                context.fillRect(x + offset.x, y + offset.y, 1, 1);
+                ctx.fillStyle = colors[value];
+                ctx.fillRect(x + offset.x, y + offset.y, 1, 1);
             }
         });
     });
+}
+
+function drawNext() {
+    nextContext.fillStyle = '#000';
+    nextContext.fillRect(0, 0, nextCanvas.width, nextCanvas.height);
+    const previewSize = nextCanvas.width / 20;
+    const offset = {
+        x: (previewSize - nextPiece[0].length) / 2,
+        y: (previewSize - nextPiece.length) / 2,
+    };
+    drawMatrix(nextPiece, offset, nextContext);
 }
 
 function draw() {
@@ -153,10 +168,11 @@ function playerMove(dir) {
 }
 
 function playerReset() {
-    const pieces = 'TJLOSZI';
-    player.matrix = createPiece(pieces[(pieces.length * Math.random()) | 0]);
+    player.matrix = nextPiece;
     player.pos.y = 0;
     player.pos.x = (arena[0].length / 2 | 0) - (player.matrix[0].length / 2 | 0);
+    nextPiece = createPiece(pieces[(pieces.length * Math.random()) | 0]);
+    drawNext();
     if (collide(arena, player)) {
         arena.forEach(row => row.fill(0));
         player.score = 0;
@@ -216,6 +232,22 @@ document.addEventListener('keydown', event => {
     }
 });
 
+[
+    ['btn-left', () => playerMove(-1)],
+    ['btn-right', () => playerMove(1)],
+    ['btn-down', playerDrop],
+    ['btn-rotate', () => playerRotate(1)],
+    ['btn-drop', hardDrop],
+].forEach(([id, fn]) => {
+    const btn = document.getElementById(id);
+    ['click', 'touchstart'].forEach(evt => {
+        btn.addEventListener(evt, e => {
+            e.preventDefault();
+            fn();
+        });
+    });
+});
+
 const colors = [
     null,
     '#00f0f0',
@@ -227,12 +259,16 @@ const colors = [
     '#f00000'
 ];
 
+const pieces = 'TJLOSZI';
+
 const arena = createMatrix(10, 20);
 const player = {
     pos: { x: 0, y: 0 },
     matrix: null,
     score: 0
 };
+
+let nextPiece = createPiece(pieces[(pieces.length * Math.random()) | 0]);
 
 playerReset();
 updateScore();


### PR DESCRIPTION
## Summary
- add next-piece preview and touch-friendly controls
- style game layout and buttons for mobile devices
- add lightweight color scheme support

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf637d488332b69be3a08c69bc06