### PR TITLE
style: add gradient styles for control buttons

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -76,6 +76,21 @@ body {
     cursor: pointer;
 }
 
+#btn-start {
+    background: linear-gradient(135deg, #28a745, #7fe37f);
+    color: #fff;
+}
+
+#btn-stop {
+    background: linear-gradient(135deg, #dc3545, #ff7b8a);
+    color: #fff;
+}
+
+#btn-refresh {
+    background: linear-gradient(135deg, #17a2b8, #5bc0de);
+    color: #fff;
+}
+
 #controls button.wide {
     width: 150px;
     border-radius: 30px;

--- a/tetris.html
+++ b/tetris.html
@@ -28,6 +28,11 @@
         </div>
         <div id="controls">
             <div class="control-row">
+                <button id="btn-start" aria-label="Start game">▶</button>
+                <button id="btn-stop" aria-label="Stop game">■</button>
+                <button id="btn-refresh" aria-label="Restart game">⟳</button>
+            </div>
+            <div class="control-row">
                 <button id="btn-rotate" aria-label="Rotate piece">⟳</button>
             </div>
             <div class="control-row">

--- a/tetris.js
+++ b/tetris.js
@@ -198,13 +198,16 @@ function playerRotate(dir) {
 let dropCounter = 0;
 let dropInterval = 1000;
 let lastTime = 0;
+let isPaused = false;
 
 function update(time = 0) {
     const deltaTime = time - lastTime;
     lastTime = time;
-    dropCounter += deltaTime;
-    if (dropCounter > dropInterval) {
-        playerDrop();
+    if (!isPaused) {
+        dropCounter += deltaTime;
+        if (dropCounter > dropInterval) {
+            playerDrop();
+        }
     }
     draw();
     requestAnimationFrame(update);
@@ -238,6 +241,14 @@ document.addEventListener('keydown', event => {
     ['btn-down', playerDrop],
     ['btn-rotate', () => playerRotate(1)],
     ['btn-drop', hardDrop],
+    ['btn-start', () => { isPaused = false; }],
+    ['btn-stop', () => { isPaused = true; }],
+    ['btn-refresh', () => {
+        arena.forEach(row => row.fill(0));
+        player.score = 0;
+        updateScore();
+        playerReset();
+    }],
 ].forEach(([id, fn]) => {
     const btn = document.getElementById(id);
     ['click', 'touchstart'].forEach(evt => {


### PR DESCRIPTION
## Summary
- add start, stop, and refresh buttons to the control panel
- style start/stop/refresh buttons with unique gradients
- allow pausing, resuming, and resetting the game via new buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe7486b648332b23d34b31222b037